### PR TITLE
Severity level filter works locally now

### DIFF
--- a/Engine/Engine/Main.cpp
+++ b/Engine/Engine/Main.cpp
@@ -22,8 +22,7 @@
 
 void logging_function()
 {
-	
-	INIReader reader("confi.ini");
+	INIReader reader("config.ini");
 	
 	std::vector<std::string> variables;
 	variables.push_back("Beans.Eh");
@@ -35,6 +34,8 @@ void logging_function()
 	BOOST_LOG_SEV(slg, DEBUG) << "This is the first value as a string. " << reader.readValue<std::string>("Beans.Smoky");
 	BOOST_LOG_SEV(slg, ERROR) << "Array values as int. " << output[0] << " + " << output[1];
 	BOOST_LOG_SEV(slg, WARNING) << "Everything crumbles, shoot me now!";
+	BOOST_LOG_SEV(slg, INFO) << "2 + 2 = 4!";
+	BOOST_LOG_SEV(slg, FATAL) << "Insert fatal error here";
 }
 
 //[ example_tutorial_attributes_named_scope
@@ -126,11 +127,13 @@ void init()
 
 int main(int, char*[])
 {
-	init();
 
+	init();
+	setSeverityLevel(FATAL);
 	named_scope_logging();
 	tagged_logging();
 	timed_logging();
+	
 	//while (true){}
 	return 0;
 }


### PR DESCRIPTION
Severity level filter properly prints out messages based on filter. If the filter is set to "WARNING", only messages higher than warning will be displayed. Resolved #3 
