### PR TITLE
INIParser functions change variables instead of returning them 

### DIFF
--- a/Engine/Engine/INIParser.cpp
+++ b/Engine/Engine/INIParser.cpp
@@ -14,8 +14,9 @@ INIParser::INIParser(const std::string& INIPath)	//overloaded constructor with f
 void INIParser::init()
 {
 	setFilePath("");
+	sectionName = "";
 	logger = logger::getSLogger();
-	BOOST_LOG_SEV(logger, INFO) << "INIHandler Initialization Completed";
+	BOOST_LOG_SEV(logger, INFO) << "INIParser Initialization Completed";
 }
 
 void INIParser::setFilePath(const std::string& INIPath)
@@ -23,7 +24,7 @@ void INIParser::setFilePath(const std::string& INIPath)
 	if (INIPath != "")	//if there is no string input, only reload the file
 	{
 		filePath = INIPath;
-		BOOST_LOG_SEV(logger, DEBUG) << "INIHandler path set to " << filePath;
+		BOOST_LOG_SEV(logger, DEBUG) << "INIParser path set to " << filePath;
 	}
 	
 	try	//attempt to load from file
@@ -36,5 +37,22 @@ void INIParser::setFilePath(const std::string& INIPath)
 		exit(0); //exit with error
 	}
 	
+}
+
+void INIParser::setSection(const std::string& newSection)
+{
+	sectionName = newSection;
+}
+
+std::string INIParser::assemblePath(const std::string& key)
+{
+	if (sectionName == "")
+	{
+		return key;						//return key if there is not section name
+	}
+	else
+	{
+		return sectionName + "." + key;	//concatenate section name and key with period
+	}
 }
 

--- a/Engine/Engine/INIParser.hpp
+++ b/Engine/Engine/INIParser.hpp
@@ -22,9 +22,9 @@ public:
 	{
 		for (int i = 0; i < vec.size(); i++)
 		{
-			if (toCopy)
+			if (toCopy[i])
 			{
-				value = toCopy;
+				vec[i] = toCopy[i];
 			};
 		}
 	}
@@ -39,20 +39,18 @@ public:
 	}
 
 	template<class T>
-	T readValue(const std::string& key)	//takes a string and return its value loaded from INI
+	void readValue(const std::string& key, T& var)	//takes a string and return its value loaded from INI
 	{
 		//tree.get would throw ptree_bad_path (ptree_error) on nonexistent value
 		boost::optional<T> op = tree.get_optional<T>(assemblePath(key)); //returns uninitialized boost::optional object if value != exist
 
 		if (op)
 		{
-			return *op;
+			var = *op;
 		}
 		else
 		{
 			BOOST_LOG_SEV(logger, INFO) << "Value not loaded from INI file \"" << filePath << "\": Section=\"" << sectionName << "\" Key=\"" << key << "\"";
-
-			return NULL; //returns null if string cannot be read
 		}
 	}
 
@@ -69,7 +67,7 @@ public:
 		std::vector<T> toReturn;
 		for (int i = 0; i < keyNames.size(); i++)
 		{
-			toReturn.push_back(readValue<T>(keyNames[i])); //get and push back value --- (NOT ASSEMBLING PATH HERE BECAUSE IT IS DONE IN readValue()
+			toReturn.push_back(readValue<T>(keyNames[i])); //get and push back value --- (NOT ASSEMBLING PATH HERE BECAUSE IT IS DONE IN readValue())
 		}
 		nullCopyVector(toReturn, endVector);
 	}
@@ -91,16 +89,12 @@ public:
 		typedef std::map<std::string, T*>::iterator it;		//construct iterator for map object
 		for (it i= valMap.begin(); i != valMap.end(); i++)	//iterate through map
 		{
-			T val = readValue<T>(i->first);		//read value and place it in the map
-			if (val)							
-			{
-				*valMap[i->first] = val;		//set value only if something was actually read
-			}
+			readValue<T>(i->first, *valMap[i->first]);		//read value and place it in the map --- (NOT ASSEMBLING PATH HERE BECAUSE IT IS DONE IN readValue())
 		}
 	}
 
 private:
-	std::string assemblePath(const std::string& key);	//concatenates section and key values
+	std::string assemblePath(const std::string& key);	//if section exists concatenate it with the key value
 
 	boost::property_tree::ptree tree;				//boost class that handles ini parsing
 	std::string filePath;							//file to read from

--- a/Engine/Engine/INIParser.hpp
+++ b/Engine/Engine/INIParser.hpp
@@ -15,12 +15,34 @@ public:
 
 	void init();
 	void setFilePath(const std::string& INIPath);
+	void setSection(const std::string& newSection);
+
+	template<class T>
+	void nullCopyVector(const std::vector<T>& toCopy, const std::vector<T>& vec)	//only copies non-null values from vector
+	{
+		for (int i = 0; i < vec.size(); i++)
+		{
+			if (toCopy)
+			{
+				value = toCopy;
+			};
+		}
+	}
+
+	template<class T>
+	void nullCopyValue(const T& toCopy, const T& value)	//only copies a non-null value
+	{
+		if (toCopy)
+		{
+			value = toCopy;
+		}
+	}
 
 	template<class T>
 	T readValue(const std::string& key)	//takes a string and return its value loaded from INI
 	{
 		//tree.get would throw ptree_bad_path (ptree_error) on nonexistent value
-		boost::optional<T> op = tree.get_optional<T>(key); //returns uninitialized boost::optional object if value != exist
+		boost::optional<T> op = tree.get_optional<T>(assemblePath(key)); //returns uninitialized boost::optional object if value != exist
 
 		if (op)
 		{
@@ -28,30 +50,28 @@ public:
 		}
 		else
 		{
-			BOOST_LOG_SEV(logger, INFO) << "Value \"" << key << "\" not loaded from INI file " << filePath;
+			BOOST_LOG_SEV(logger, INFO) << "Value not loaded from INI file \"" << filePath << "\": Section=\"" << sectionName << "\" Key=\"" << key << "\"";
 
 			return NULL; //returns null if string cannot be read
 		}
 	}
 
 	template<class T>
-	void writeValue(const std::string& header, T value) //writes value to ini file
+	void writeValue(const std::string& key, T value) //writes value to ini file
 	{
-		tree.put(header, value);
-		write_ini("config.ini", tree);
+		tree.put(assemblePath(key), value);		//adds value to tree
+		write_ini("config.ini", tree);	//actually writes to INI file
 	}
 
-	
-
 	template<class T>
-	std::vector<T> readVector(const std::vector<std::string> &keyNames)	//reads vector of strings and returns vector of matching values as loaded from ini value
+	void readVector(const std::vector<std::string> &keyNames, std::vector<T>& endVector)	//reads vector of strings and returns vector of matching values as loaded from ini value
 	{
 		std::vector<T> toReturn;
 		for (int i = 0; i < keyNames.size(); i++)
 		{
-			toReturn.push_back(readValue<T>(keyNames[i])); //get and push back value
+			toReturn.push_back(readValue<T>(keyNames[i])); //get and push back value --- (NOT ASSEMBLING PATH HERE BECAUSE IT IS DONE IN readValue()
 		}
-		return toReturn;
+		nullCopyVector(toReturn, endVector);
 	}
 
 	template<class T>
@@ -61,12 +81,12 @@ public:
 
 		for (it i = values.begin(); i != values.end(); i++)
 		{
-			writeValue(i->first, *values[i->first]);
+			writeValue(i->first, *values[i->first]);	
 		}
 	}
 
 	template<class T>
-	void readWriteMap(std::map < std::string, T*>& valMap)
+	void readMap(std::map < std::string, T*>& valMap)
 	{
 		typedef std::map<std::string, T*>::iterator it;		//construct iterator for map object
 		for (it i= valMap.begin(); i != valMap.end(); i++)	//iterate through map
@@ -80,8 +100,11 @@ public:
 	}
 
 private:
+	std::string assemblePath(const std::string& key);	//concatenates section and key values
+
 	boost::property_tree::ptree tree;				//boost class that handles ini parsing
 	std::string filePath;							//file to read from
 	src::severity_logger<severity_level> logger;	//logger to handle debuging and errors
+	std::string sectionName;						//name of current section
 };
 

--- a/Engine/Engine/Logger.cpp
+++ b/Engine/Engine/Logger.cpp
@@ -1,0 +1,65 @@
+#include "Logger.hpp"
+
+
+// The operator puts a human-friendly representation of the severity level to the stream
+std::ostream& operator<< (std::ostream& strm, severity_level level)
+{
+	static const char* strings[] =
+	{
+		"debug",
+		"info",
+		"warning",
+		"error",
+		"fatal"
+	};
+
+	if (static_cast< std::size_t >(level) < sizeof(strings) / sizeof(*strings))
+		strm << strings[level];
+	else
+		strm << static_cast< int >(level);
+
+	return strm;
+}
+
+void logger::setSeverityLevel(const severity_level& newLevel)
+{
+	logging::core::get()->set_filter(expr::attr<severity_level>("Severity") >= newLevel);
+}
+
+src::severity_logger<severity_level> logger::getSLogger()
+{
+	src::severity_logger<severity_level> sl;
+	return sl;
+}
+
+void logger::init()
+{
+	typedef sinks::synchronous_sink< sinks::text_ostream_backend > text_sink;
+	boost::shared_ptr< text_sink > sink = boost::make_shared< text_sink >();
+
+	sink->locked_backend()->add_stream(
+		boost::make_shared< std::ofstream >("sample.log"));
+
+	sink->set_formatter	//setting formatting for log output based on attributes
+		(
+		expr::stream
+		<< std::dec << std::setw(8) << std::setfill('0') << line_id << std::dec << std::setfill(' ')	//output types hardcoded here ie(std::dec)
+		<< ": <" << severity << ">\t"
+		<< "(" << scope << ") "
+		<< expr::if_(expr::has_attr(tag_attr))
+		[
+			expr::stream << "[" << tag_attr << "] "
+		]
+	<< expr::if_(expr::has_attr(timeline))
+		[
+			expr::stream << "[" << timeline << "] "
+		]
+	<< expr::smessage
+		);
+
+	logging::core::get()->add_sink(sink);
+
+	// Add attributes
+	logging::add_common_attributes();
+	logging::core::get()->add_global_attribute("Scope", attrs::named_scope());
+}

--- a/Engine/Engine/Logger.hpp
+++ b/Engine/Engine/Logger.hpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <string>
 #include <ostream>
+#include <iostream>
 #include <fstream>
 #include <iomanip>
 #include <boost/shared_ptr.hpp>
@@ -44,53 +45,19 @@ BOOST_LOG_ATTRIBUTE_KEYWORD(tag_attr, "Tag", std::string)
 BOOST_LOG_ATTRIBUTE_KEYWORD(scope, "Scope", attrs::named_scope::value_type)
 BOOST_LOG_ATTRIBUTE_KEYWORD(timeline, "Timeline", attrs::timer::value_type)
 
+
+
 namespace logger
 {
 	//sets level for maximum level of output ex (level of INFO would not output DEBUG level statements)
-	inline void setSeverityLevel(const severity_level &newLevel)
-	{
-		logging::core::get()->set_filter(expr::attr<severity_level>("Severity") >= newLevel);
-	}
+	void setSeverityLevel(const severity_level &newLevel);
 
 	//wrapper to return severity logger
-	inline src::severity_logger<severity_level> getSLogger() //should return standard ref to class memeber?s 
-	{
-		src::severity_logger<severity_level> sl;
-		return sl;
-	}
+	src::severity_logger<severity_level> getSLogger(); //should return standard ref to class memeber?s 
 
 	//initialization function
-	inline void init()
-	{
-		typedef sinks::synchronous_sink< sinks::text_ostream_backend > text_sink;
-		boost::shared_ptr< text_sink > sink = boost::make_shared< text_sink >();
+	void init();
 
-		sink->locked_backend()->add_stream(
-			boost::make_shared< std::ofstream >("sample.log"));
-
-		sink->set_formatter	//setting formatting for log output based on attributes
-			(
-			expr::stream
-			<< std::dec << std::setw(8) << std::setfill('0') << line_id << std::dec << std::setfill(' ')	//output types hardcoded here ie(std::dec)
-			<< ": <" << severity << ">\t"
-			<< "(" << scope << ") "
-			<< expr::if_(expr::has_attr(tag_attr))
-			[
-				expr::stream << "[" << tag_attr << "] "
-			]
-		<< expr::if_(expr::has_attr(timeline))
-			[
-				expr::stream << "[" << timeline << "] "
-			]
-		<< expr::smessage
-			);
-
-		logging::core::get()->add_sink(sink);
-
-		// Add attributes
-		logging::add_common_attributes();
-		logging::core::get()->add_global_attribute("Scope", attrs::named_scope());
-	}
 }
 
 

--- a/Engine/Engine/Main.cpp
+++ b/Engine/Engine/Main.cpp
@@ -10,7 +10,7 @@ void logging_function()
 
 	INIParser reader("config.ini");
 
-	int one = 5, two = 1, three = 3;
+	int one, two = 1, three = 3;
 	std::map<std::string, int*> variables;
 	variables["Beans.Ehhh"] = &one;
 	variables["Beans.Meh"] = &two;
@@ -35,25 +35,7 @@ void logging_function()
 	BOOST_LOG_SEV(slg, INFO) << "Here goes the tagged record";
 }
 
-// The operator puts a human-friendly representation of the severity level to the stream
-std::ostream& operator<< (std::ostream& strm, severity_level level)
-{
-	static const char* strings[] =
-	{
-		"debug",
-		"info",
-		"warning",
-		"error",
-		"fatal"
-	};
 
-	if (static_cast< std::size_t >(level) < sizeof(strings) / sizeof(*strings))
-		strm << strings[level];
-	else
-		strm << static_cast< int >(level);
-
-	return strm;
-}
 
 int main(int, char*[])
 {

--- a/Engine/Engine/Main.cpp
+++ b/Engine/Engine/Main.cpp
@@ -10,29 +10,28 @@ void logging_function()
 
 	INIParser reader("config.ini");
 
-	int one, two = 1, three = 3;
+	int one =3, two = 1, three = 3;
+	reader.setSection("Beans");
 	std::map<std::string, int*> variables;
-	variables["Beans.Ehhh"] = &one;
-	variables["Beans.Meh"] = &two;
-	variables["Beans.Heh"] = &three;
-	
+	variables["Ehhh"] = &one;
+	variables["Meh"] = &two;
+	variables["Heh"] = &three;
+	std::string testing = "test";
+	reader.readValue<std::string>("string", testing);
+	reader.readMap<int>(variables);
+
+	reader.setSection("");
 	reader.writeValue<int>("Eugene.cookies", 7);	//Adds header called "eugene" with an attribute called "cookies" which has a value of 7
-	reader.writeMap<int>(variables);
-	reader.readWriteMap<int>(variables);
+
 	auto slg = logger::getSLogger();
 	slg.add_attribute("Scope", attrs::named_scope());
+	int cookies = 1;
+	reader.readValue<int>("Eugene.cookies", cookies);
 	//BOOST_LOG_SEV(slg, DEBUG) << "This is the first value as a string. " << reader.readValue<std::string>("Beans.Smoky");
 	BOOST_LOG_SEV(slg, ERROR) << "Array values as int. " << one << " + " << two;
+	BOOST_LOG_SEV(slg, INFO) << "This is a string: " << testing;
+	BOOST_LOG_SEV(slg, ERROR) << "Eugene's cookies: " << cookies;
 
-	BOOST_LOG_SEV(slg, ERROR) << "Eugene's cookies: " << reader.readValue<std::string>("Eugene.cookies");
-
-	BOOST_LOG_SCOPED_THREAD_ATTR("Timeline", attrs::timer());
-
-	BOOST_LOG_SEV(slg, INFO) << "Starting to time nested functions";
-
-	BOOST_LOG_SEV(slg, INFO) << "Stopping to time nested functions";
-
-	BOOST_LOG_SEV(slg, INFO) << "Here goes the tagged record";
 }
 
 

--- a/Engine/Engine/config.ini
+++ b/Engine/Engine/config.ini
@@ -4,4 +4,3 @@ cookies=7
 Eh=5
 Heh=3
 Meh=1
-Ehhh=-858993460

--- a/Engine/Engine/config.ini
+++ b/Engine/Engine/config.ini
@@ -1,6 +1,7 @@
 [Eugene]
 cookies=7
 [Beans]
-Ehhh=5
+Eh=5
 Heh=3
 Meh=1
+Ehhh=-858993460


### PR DESCRIPTION
Made INIParser functions take variables by reference and then change them
within the function.  This allows for automatic support for default
values.  And solves crashes resulting from items with null values.
