### PR TITLE
Fixed a possible error with Layers

### DIFF
--- a/Engine/Engine/Layers/Layer.cpp
+++ b/Engine/Engine/Layers/Layer.cpp
@@ -7,6 +7,7 @@ Layer::Layer()
 {
 	scrollBounded = false;				//by default, scrollBoundedness is false
 	scrollTracker = sf::Vector2f(0, 0);	//the scrollTracker starts at (0,0)
+	oldScrollTracker = scrollTracker;
 }
 
 Layer::~Layer()
@@ -138,7 +139,6 @@ sf::Vector2f Layer::getScrollDistance(const sf::Vector2f& scrollDist)
 {
 	//keep track of the scrolling 
 
-	const sf::Vector2f oldTrackVal = scrollTracker;
 
 	sf::Vector2f dist;
 	dist.x = scrollSpeed.x * scrollDist.x;
@@ -150,15 +150,28 @@ sf::Vector2f Layer::getScrollDistance(const sf::Vector2f& scrollDist)
 
 	
 	//then return the difference between the bounded scrolltracking value and the old scrolltracking value
-	const sf::Vector2f corDist = getCorrectiveDistance();		//get the corrective distance that will align the layer to the bounds
+	
 	if (scrollBounded)
 	{
-		moveCorners(corDist);									//apply the displacement
-		scrollTracker += corDist;
+		const sf::Vector2f corDist = getCorrectiveDistance();						//get the corrective distance that will align the layer to the bounds 
 
+		const sf::Vector2f retTmp = (scrollTracker - oldScrollTracker + corDist);	//should be 0 if the scrollTracker was out of bounds last time
+
+		oldScrollTracker = scrollTracker + corDist;
+
+		return retTmp;
 
 	}
-	return (scrollTracker - oldTrackVal);
+	else
+	{
+		const sf::Vector2f retTmp = (scrollTracker - oldScrollTracker);
+
+		oldScrollTracker = scrollTracker;
+
+		return retTmp;
+		
+	}
+	
 }
 
 

--- a/Engine/Engine/Layers/Layer.hpp
+++ b/Engine/Engine/Layers/Layer.hpp
@@ -83,6 +83,8 @@ private:
 
 	sf::Vector2f scrollTracker;							//keeps track of the scrolling
 
+	sf::Vector2f oldScrollTracker;
+
 	
 
 

--- a/Engine/Engine/Utilities.hpp
+++ b/Engine/Engine/Utilities.hpp
@@ -87,6 +87,36 @@ namespace util
 	}
 
 
+
+
+	inline float fmax(float& a, float& b)
+	{
+		return ((a > b) ? a : b);
+	}
+
+	inline float fmin(float& a, float& b)
+	{
+		return ((a < b) ? a : b);
+	}
+
+	inline void fbound(float& a, const float& b, const float& c)
+	{
+		if (b > c)
+		{
+			if (a > b){ a = b; }
+			else if (a < c){ a = c; }
+		}
+		else
+		{
+			if (a > c){ a = c; }
+			else if (a < b) { a = b; }
+		}
+	}
+
+
+
+
+
 	inline unsigned int uimax(unsigned int& a, unsigned int& b)
 	{
 		return ((a > b) ? a : b);


### PR DESCRIPTION
This is a small patch to fix a possible error. If you want to go past the scroll bounds, it will let you, but it needs to know how much because you shouldn't immediately start scrolling the other direction if you turn around; there should be an equal waiting period of non-scrolling. Also added three util functions.
